### PR TITLE
unbaka vanilla apps [1/2]

### DIFF
--- a/snippets/blaze.xml
+++ b/snippets/blaze.xml
@@ -96,6 +96,8 @@
   <project path="packages/apps/Launcher3" name="packages_apps_Launcher3" remote="blaze" />
   <project path="packages/apps/Updater" name="packages_apps_Updater" revision="14" remote="blaze" />
   <project path="packages/apps/DocumentsUI" name="packages_apps_DocumentsUI" remote="blaze" />
+  <project path="packages/apps/Dialer" name="packages_apps_Dialer" remote="blaze" />
+  <project path="packages/apps/Messaging" name="packages_apps_Messaging" remote="blaze" />
 
   <!-- Remote Packages Modules -->
   <project path="packages/modules/Bluetooth" name="packages_modules_Bluetooth" remote="blaze" />

--- a/snippets/blaze.xml
+++ b/snippets/blaze.xml
@@ -95,6 +95,7 @@
   <project path="packages/apps/ThemePicker" name="packages_apps_ThemePicker" remote="blaze" />
   <project path="packages/apps/Launcher3" name="packages_apps_Launcher3" remote="blaze" />
   <project path="packages/apps/Updater" name="packages_apps_Updater" revision="14" remote="blaze" />
+  <project path="packages/apps/DocumentsUI" name="packages_apps_DocumentsUI" remote="blaze" />
 
   <!-- Remote Packages Modules -->
   <project path="packages/modules/Bluetooth" name="packages_modules_Bluetooth" remote="blaze" />

--- a/snippets/blaze.xml
+++ b/snippets/blaze.xml
@@ -119,4 +119,7 @@
   <project path="vendor/gms" name="vendor_gms" remote="blaze-gitea" revision="14-QPR2" clone-depth="1" />
   <project path="vendor/support" name="vendor_support" remote="blaze" revision="14"  />
   <project path="vendor/qcom/opensource/vibrator" name="vendor_qcom_opensource_vibrator" revision="14" remote="blaze" />
+
+  <!-- Remote Prebuilts -->
+  <project path="prebuilts/exthm-sdk" name="exthmui-next/android_prebuilts_exthmui-sdk" revision="Utsuho" remote="github" />
 </manifest>

--- a/snippets/lineage.xml
+++ b/snippets/lineage.xml
@@ -161,4 +161,9 @@
   <project path="vendor/nxp/secure_element" name="android_vendor_nxp_secure_element" remote="lineage" revision="lineage-20.0" />
   <project path="vendor/nxp/secure_element_extns" name="android_vendor_nxp_secure_element_extns" remote="lineage" revision="lineage-20.0" />
 
+  <!-- Apps -->
+  <project path="packages/apps/Contacts" name="android_packages_apps_Contacts" remote="lineage" />
+  <project path="packages/apps/DeskClock" name="android_packages_apps_DeskClock" remote="lineage" />
+  <project path="packages/apps/Glimpse" name="android_packages_apps_Glimpse" remote="lineage" />
+
 </manifest>

--- a/snippets/remove.xml
+++ b/snippets/remove.xml
@@ -125,6 +125,8 @@
 
   <!-- Packages repos -->
   <remove-project name="platform/packages/apps/Calendar" />
+  <remove-project name="platform/packages/apps/Contacts" />
+  <remove-project name="platform/packages/apps/DeskClock" />
   <remove-project name="platform/packages/apps/Settings" />
   <remove-project name="platform/packages/apps/Nfc" />
   <remove-project name="platform/packages/apps/Launcher3" />

--- a/snippets/remove.xml
+++ b/snippets/remove.xml
@@ -127,6 +127,7 @@
   <remove-project name="platform/packages/apps/Calendar" />
   <remove-project name="platform/packages/apps/Contacts" />
   <remove-project name="platform/packages/apps/DeskClock" />
+  <remove-project name="platform/packages/apps/DocumentsUI" />
   <remove-project name="platform/packages/apps/Settings" />
   <remove-project name="platform/packages/apps/Nfc" />
   <remove-project name="platform/packages/apps/Launcher3" />

--- a/snippets/remove.xml
+++ b/snippets/remove.xml
@@ -127,7 +127,9 @@
   <remove-project name="platform/packages/apps/Calendar" />
   <remove-project name="platform/packages/apps/Contacts" />
   <remove-project name="platform/packages/apps/DeskClock" />
+  <remove-project name="platform/packages/apps/Dialer" />
   <remove-project name="platform/packages/apps/DocumentsUI" />
+  <remove-project name="platform/packages/apps/Messaging" />
   <remove-project name="platform/packages/apps/Settings" />
   <remove-project name="platform/packages/apps/Nfc" />
   <remove-project name="platform/packages/apps/Launcher3" />


### PR DESCRIPTION
aosp apps currently used in vanilla is kinda out of date
this patchset aims to "update" these

modified apps:
- [Messaging](https://github.com/ifritPatches/platform_packages_apps_Messaging)
- [Dialer](https://github.com/ifritPatches/platform_packages_apps_Dialer)
- [DocumentsUI](https://github.com/ifritPatches/platform_packages_apps_DocumentsUI)

tracked apps:
- Contacts, DeskClock, Glimpse from LineageOS
- exthmui-sdk fron exthmui-next (for Material 3 prebuilt libs)

credits:
- [exthmui-next](https://github.com/exthmui-next) for Material You modifications used in Messaging and Dialer
- [RisingTechOSS](https://github.com/RisingTechOSS) for Material You colored DocumentsUI
- respective commit authors

drafted PR since i dont have these tested, yet